### PR TITLE
Treat foot=use_sidepath as equivalent to foot=no

### DIFF
--- a/Hiking.brf
+++ b/Hiking.brf
@@ -162,9 +162,9 @@ assign bikeaccess
 
 assign footaccess     or any_hiking_route 
                       or issidewalk 
-                      or and bikeaccess  not foot=no
+                      or and bikeaccess  not foot=no|use_sidepath
                       or bicycle=dismount
-                      switch foot=      defaultaccess    not foot=private|no
+                      switch foot=      defaultaccess    not foot=private|no|use_sidepath
                          
 assign accesspenalty switch footaccess 0 9998
 


### PR DESCRIPTION
According to [OSM Wiki](https://wiki.openstreetmap.org/wiki/Tag:foot%3Duse_sidepath#Status),

> Unlike [bicycle](https://wiki.openstreetmap.org/wiki/Key:bicycle)=[use_sidepath](https://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath), this tag was never properly proposed and accepted. Due to its considerable use however (often in combination with [bicycle](https://wiki.openstreetmap.org/wiki/Key:bicycle)=[use_sidepath](https://wiki.openstreetmap.org/wiki/Tag:bicycle%3Duse_sidepath)), routing engines should treat it as a negative access value (i.e., equivalent to [foot](https://wiki.openstreetmap.org/wiki/Key:foot)=[no](https://wiki.openstreetmap.org/wiki/Tag:foot%3Dno) or a bit weaker) to prevent pedestrian users from being routed along ways with parallel compulsory sidepaths.  